### PR TITLE
FEAT | Calculating physical stores within a radius

### DIFF
--- a/src/controllers/storeController.ts
+++ b/src/controllers/storeController.ts
@@ -116,16 +116,20 @@ export const deleteStore = async (req: Request, res: Response): Promise<void> =>
   }
 }
 
-export const getNearbyStores = async (req: Request, res: Response) => {
-  const postalCode = req.query.postalCode as string;
+export const getNearbyStores = async (req: Request, res: Response): Promise<void> => {
+  const postalCode = req.params.postalCode as string;
 
   if (!postalCode) {
-    return res.status(400).json({ error: 'Postal code is required.' });
+    res.status(400).json({ error: 'Postal code is required.' });
+    return;
   }
 
   try {
     const allStores = await storeService.getAllStores();
+    console.log(allStores);
+    
     const nearbyStores = await findNearbyStores(postalCode, allStores);
+
 
     res.status(200).json({
       status: 'success',

--- a/src/controllers/storeController.ts
+++ b/src/controllers/storeController.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from 'express';
 import * as storeService from '../services/storeService';
+import { findNearbyStores } from '../services/addressService';
 
 export const createStore = async (req: Request, res: Response) => {
   try {

--- a/src/controllers/storeController.ts
+++ b/src/controllers/storeController.ts
@@ -115,3 +115,29 @@ export const deleteStore = async (req: Request, res: Response): Promise<void> =>
     })
   }
 }
+
+export const getNearbyStores = async (req: Request, res: Response) => {
+  const postalCode = req.query.postalCode as string;
+
+  if (!postalCode) {
+    return res.status(400).json({ error: 'Postal code is required.' });
+  }
+
+  try {
+    const allStores = await storeService.getAllStores();
+    const nearbyStores = await findNearbyStores(postalCode, allStores);
+
+    res.status(200).json({
+      status: 'success',
+      message: 'Nearby stores within 100km of postal code.',
+      stores: nearbyStores
+    })
+
+  } catch (error: any) {
+    res.status(500).json({
+      status: 'failed',
+      message: 'Error fetching nearby stores.',
+      error: error.message
+    })
+  }
+}

--- a/src/models/addressModel.ts
+++ b/src/models/addressModel.ts
@@ -8,6 +8,9 @@ export interface AddressProps extends Document {
   city: string;
   state: string;
   postalCode: string;
+  country: string;
+  latitude: number;
+  longitude: number;
 }
 
 export const addressSchema: Schema = new Schema({
@@ -18,6 +21,9 @@ export const addressSchema: Schema = new Schema({
   city: { type: String, required: true },
   state: { type: String, required: true },
   postalCode: { type: String, required: true },
+  country: { type: String, required: true },
+  latitude: { type: Number, required: true },
+  longitude: { type: Number, required: true }
 });
 
 export const Address = mongoose.model<AddressProps>('Address', addressSchema);

--- a/src/routes/storeRoute.ts
+++ b/src/routes/storeRoute.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { createStore, deleteStore, getAllStores, getStoreById, updateStore } from '../controllers/storeController';
+import { createStore, deleteStore, getAllStores, getNearbyStores, getStoreById, updateStore } from '../controllers/storeController';
 
 const router = Router();
 
@@ -13,5 +13,9 @@ router
   .get(getStoreById)
   .patch(updateStore)
   .delete(deleteStore);
+
+router
+  .route('/nearby/:postalCode')
+  .get(getNearbyStores);
 
 export default router;

--- a/src/services/addressService.ts
+++ b/src/services/addressService.ts
@@ -12,7 +12,7 @@ export const getAddressByPostalCode = async (cep: string): Promise<any> => {
     return address;
 
   } catch (error) {
-    throw new Error('Erro ao buscar CEP.');
+    throw new Error('Error searching for postal code.');
   }
 }
 
@@ -27,7 +27,7 @@ export const getCoordinates = async (address: string): Promise<{ latitude: numbe
     return { latitude: latitude, longitude: longitude };
     
   } catch (error) {
-    throw new Error('Erro ao buscar coordenadas.')
+    throw new Error('Error searching for coordinates.')
   }
 }
 

--- a/src/services/addressService.ts
+++ b/src/services/addressService.ts
@@ -42,10 +42,15 @@ export const findNearbyStores = async (
 
   const userCoordinates = await getCoordinates(formattedAddress);
 
-  const nearbyStores = stores.map(store => ({
-    name: store.name,
-    distance: calculateHaversineDistance(userCoordinates.latitude, userCoordinates.longitude, store.address.latitude, store.address.longitude)
-  }))
+  const nearbyStores = stores.map(store => {
+
+    const distance = calculateHaversineDistance(userCoordinates.latitude, userCoordinates.longitude, store.address.latitude, store.address.longitude);
+
+    return {
+      name: store.name,
+      distance: parseFloat(distance.toFixed(3))
+    }
+  })
   .filter(store => store.distance <= 100)
   .sort((a, b) => a.distance - b.distance);
 

--- a/src/services/addressService.ts
+++ b/src/services/addressService.ts
@@ -47,7 +47,7 @@ export const findNearbyStores = async (
     distance: calculateHaversineDistance(userCoordinates.latitude, userCoordinates.longitude, store.address.latitude, store.address.longitude)
   }))
   .filter(store => store.distance <= 100)
-  .sort((a, b) => a.distance = b.distance);
+  .sort((a, b) => a.distance - b.distance);
 
   return nearbyStores;
 }

--- a/src/services/addressService.ts
+++ b/src/services/addressService.ts
@@ -22,9 +22,9 @@ export const getCoordinates = async (address: string): Promise<{ latitude: numbe
 
   try {
     const response = await axios.get(url);
-    const { latitude, longitude } = response.data.results[0].geometry;
+    const { lat, lng } = response.data.results[0].geometry;
 
-    return { latitude: latitude, longitude: longitude };
+    return { latitude: lat, longitude: lng };
     
   } catch (error) {
     throw new Error('Error searching for coordinates.')

--- a/src/services/addressService.ts
+++ b/src/services/addressService.ts
@@ -11,6 +11,21 @@ export const getAddressByCep = async (cep: string): Promise<any> => {
     return address;
 
   } catch (error) {
-    throw new Error('Erro ao buscar CEP');
+    throw new Error('Erro ao buscar CEP.');
+  }
+}
+
+export const getCoordinates = async (address: string): Promise<{ latitude: number; longitude: number}> => {
+  const formattedAddress = address.replace(/ /g, '+');
+  const url = `${process.env.OPENCAGE_URL}?q=${encodeURIComponent(formattedAddress)}&key=${process.env.OPENCAGE_API_KEY}`;
+
+  try {
+    const response = await axios.get(url);
+    const { lat, lng } = response.data.results[0].geometry;
+
+    return { latitude: lat, longitude: lng };
+    
+  } catch (error) {
+    throw new Error('Erro ao buscar coordenadas.')
   }
 }

--- a/src/services/addressService.ts
+++ b/src/services/addressService.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import { AddressProps } from '../models/addressModel';
 import { calculateHaversineDistance } from '../utils/calculateHaversineDistance';
+import { StoreProps } from '../models/storeModel';
 
 export const getAddressByPostalCode = async (cep: string): Promise<any> => {
   const url = `${process.env.VIA_CEP_URL}/${cep}/json/`;
@@ -33,7 +34,7 @@ export const getCoordinates = async (address: string): Promise<{ latitude: numbe
 
 export const findNearbyStores = async (
   postalCode: string,
-  stores: Array<{ name: string; latitude: number; longitude: number }>
+  stores: Array<StoreProps>
 ): Promise<Array<{ name: string; distance: number }>> => {
 
   const addressData = await getAddressByPostalCode(postalCode);
@@ -43,7 +44,7 @@ export const findNearbyStores = async (
 
   const nearbyStores = stores.map(store => ({
     name: store.name,
-    distance: calculateHaversineDistance(userCoordinates.latitude, userCoordinates.longitude, store.latitude, store.longitude)
+    distance: calculateHaversineDistance(userCoordinates.latitude, userCoordinates.longitude, store.address.latitude, store.address.longitude)
   }))
   .filter(store => store.distance <= 100)
   .sort((a, b) => a.distance = b.distance);

--- a/src/services/addressService.ts
+++ b/src/services/addressService.ts
@@ -21,9 +21,9 @@ export const getCoordinates = async (address: string): Promise<{ latitude: numbe
 
   try {
     const response = await axios.get(url);
-    const { lat, lng } = response.data.results[0].geometry;
+    const { latitude, longitude } = response.data.results[0].geometry;
 
-    return { latitude: lat, longitude: lng };
+    return { latitude: latitude, longitude: longitude };
     
   } catch (error) {
     throw new Error('Erro ao buscar coordenadas.')

--- a/src/services/addressService.ts
+++ b/src/services/addressService.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 import { AddressProps } from '../models/addressModel';
 
 export const getAddressByCep = async (cep: string): Promise<any> => {
-  const url = `https://viacep.com.br/ws/${cep}/json/`;
+  const url = `${process.env.VIA_CEP_URL}/${cep}/json/`;
 
   try {
     const response = await axios.get<AddressProps>(url);

--- a/src/services/storeService.ts
+++ b/src/services/storeService.ts
@@ -1,6 +1,6 @@
 import { Address } from "../models/addressModel";
 import { Store, StoreProps } from "../models/storeModel"
-import { getAddressByPostalCode } from "./addressService";
+import { getAddressByPostalCode, getCoordinates } from "./addressService";
 
 interface storeDataProps {
   name: string;
@@ -19,6 +19,9 @@ interface storeDataProps {
 export const createStore = async (storeData: storeDataProps): Promise<StoreProps> => {
   const addressData = await getAddressByPostalCode(storeData.address.postalCode);
 
+  const formattedAddress = `${addressData.logradouro},${addressData.uf},${addressData.localidade}`;
+  const coordinates = await getCoordinates(formattedAddress);
+
   const completeAddress = new Address({
     street: addressData.logradouro,
     neighborhood: addressData.bairro,
@@ -26,7 +29,10 @@ export const createStore = async (storeData: storeDataProps): Promise<StoreProps
     state: addressData.estado,
     postalCode: storeData.address.postalCode,
     number: storeData.address.number,
-    complement: storeData.address?.complement
+    complement: storeData.address?.complement,
+    country: 'Brasil',
+    latitude: coordinates.latitude,
+    longitude: coordinates.longitude
   });
 
   const store = new Store({ ...storeData, address: completeAddress });

--- a/src/services/storeService.ts
+++ b/src/services/storeService.ts
@@ -1,6 +1,6 @@
 import { Address } from "../models/addressModel";
 import { Store, StoreProps } from "../models/storeModel"
-import { getAddressByCep } from "./addressService";
+import { getAddressByCep, getCoordinates } from "./addressService";
 
 interface storeDataProps {
   name: string;
@@ -17,7 +17,6 @@ interface storeDataProps {
 }
 
 export const createStore = async (storeData: storeDataProps): Promise<StoreProps> => {
-
   const addressData = await getAddressByCep(storeData.address.postalCode);
 
   const completeAddress = new Address({

--- a/src/services/storeService.ts
+++ b/src/services/storeService.ts
@@ -1,6 +1,6 @@
 import { Address } from "../models/addressModel";
 import { Store, StoreProps } from "../models/storeModel"
-import { getAddressByCep, getCoordinates } from "./addressService";
+import { getAddressByPostalCode } from "./addressService";
 
 interface storeDataProps {
   name: string;
@@ -17,7 +17,7 @@ interface storeDataProps {
 }
 
 export const createStore = async (storeData: storeDataProps): Promise<StoreProps> => {
-  const addressData = await getAddressByCep(storeData.address.postalCode);
+  const addressData = await getAddressByPostalCode(storeData.address.postalCode);
 
   const completeAddress = new Address({
     street: addressData.logradouro,

--- a/src/utils/calculateHaversineDistance.ts
+++ b/src/utils/calculateHaversineDistance.ts
@@ -1,0 +1,19 @@
+export function calculateHaversineDistance(latitude1: number, longitude1: number, latitude2: number, longitude2: number): number {
+  const earthRadiusKM = 6371;
+  const latitudeDifference = (latitude2 - latitude1) * (Math.PI / 180);
+  const longitudeDifference = (longitude2 - longitude1) * (Math.PI / 180);
+
+  const latitude1InRadians = latitude1 * (Math.PI / 180);
+  const latitude2InRadians = latitude2 * (Math.PI / 180);
+
+  const haversineFormulaComponent = 
+    Math.sin(latitudeDifference / 2) * Math.sin(latitudeDifference / 2) +
+    Math.cos(latitude1InRadians) * Math.cos(latitude2InRadians) *
+    Math.sin(longitudeDifference / 2) * Math.sin(longitudeDifference / 2);
+  
+  const angularDistance = 2 * Math.atan2(Math.sqrt(haversineFormulaComponent), Math.sqrt(1 - haversineFormulaComponent));
+
+  const distanceInKM = earthRadiusKM * angularDistance;
+
+  return distanceInKM;
+}


### PR DESCRIPTION
### Description:
Implemented features to enhance store location functionalities, including fetching coordinates from OpenCage API, calculating distances and finding nearby stores.

### Tasks done:
- Moved ViaCEP URL to an environment variable
- Created a function to fetch coordinates from the OpenCage API
- Implemented the find nearby stores function to retrieve stores within a specified radius
- Added latitude and longitude fields to the address model
- Populated latitude and longitude data when creating a store with an address
- Created the controller to handle requests for nearby stores
- Added the route to access the nearby stores feature

### New API endpoint:
Method: GET
Route:  /api/v1/stores/nearby/:postalCode
Status code: 200

### Request Parameters
- postalCode: The postal code from which to search for nearby stores.

### Response Structure:
```json
{
    "status": "success",
    "message": "Nearby stores within 100km of postal code.",
    "stores": [
        {
            "name": "Example store",
            "distance": 7.96
        }
}
```
